### PR TITLE
[Temp fix] Revert triton-viz version to use old version for triton, hash 62cb630

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -44,7 +44,7 @@
         "# Only need to run the first time.\n",
         "# Works with latest triton. Sorry, this takes a minute to install.\n",
         "!pip install jaxtyping\n",
-        "!pip install git+https://github.com/Deep-Learning-Profiling-Tools/triton-viz\n",
+        "!pip install git+https://github.com/Deep-Learning-Profiling-Tools/triton-viz@62cb630\n",
         "!wget \"https://dl.cloudsmith.io/public/test-wha/triton-puzzles/raw/files/triton-3.0.0-cp310-cp310-linux_x86_64.whl\"\n",
         "!mv triton-3.0.0*.whl triton-3.0.0-cp310-cp310-linux_x86_64.whl\n",
         "!pip install triton-3.0.0-cp310-cp310-linux_x86_64.whl\n",


### PR DESCRIPTION
(This is mostly for Colab usage) 

The Colab notebook stopped working for me sometime this afternoon. In the third code cell, I was getting errors of the form`cannot import name 'interpreter_builder' from 'triton.runtime.interpreter'` when  trying to import the triton_viz library.  

I was able to cross-match this timing with commits in the triton-viz library (https://github.com/Deep-Learning-Profiling-Tools/triton-viz/commit/65a0ef4412183f0b17426a2007fb3a7f310503f8). I made a change which installs a slightly older version of triton-viz, and this seems to work for now. 

In discord, @Jokeren was recommending to rebuild triton from source, but unfortunately this doesn't seem to cooperate well with Colab (something goes wrong when running `pip install -e python`). Open to other fixes, I just thought this was the simplest to implement.