### PR TITLE
minor on puzzle 11

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -3,8 +3,8 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/srush/Triton-Puzzles/blob/main/Triton-Puzzles.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -849,13 +849,13 @@
         "Uses three program id axes. Block size `B2` represent the batches to process out of `N2`.\n",
         "Block size `B0` represent the rows of `x` to process out of `N0`. Block size `B1` represent the cols of `y` to process out of `N1`. The middle shape is `MID`.\n",
         "\n",
-        "$$z_{i, j, k} = \\sum_{k} x_{i,j, l} \\times y_{i, l, k} \\text{ for } i = 1\\ldots N_2, j = 1\\ldots N_0, k = 1\\ldots N_1$$\n",
+        "$$z_{i, j, k} = \\sum_{l} x_{i,j, l} \\times y_{i, l, k} \\text{ for } i = 1\\ldots N_2, j = 1\\ldots N_0, k = 1\\ldots N_1$$\n",
         "\n",
         "You are allowed to use `tl.dot` which computes a smaller mat mul.\n",
         "\n",
         "Hint: the main trick is that you can split a matmul into smaller parts.\n",
         "\n",
-        "$$z_{i, j, k} = \\sum_{k=1}^{K/2} x_{i,j, l} \\times y_{i, l, k} +  \\sum_{k=K/2}^{K} x_{i,j, l} \\times y_{i, l, k} $$\n"
+        "$$z_{i, j, k} = \\sum_{l=1}^{L/2} x_{i,j, l} \\times y_{i, l, k} +  \\sum_{l=L/2}^{L} x_{i,j, l} \\times y_{i, l, k} $$\n"
       ]
     },
     {
@@ -881,12 +881,12 @@
         "    return x @ y\n",
         "\n",
         "@triton.jit\n",
-        "def dot_kernel(x_ptr, y_ptr, z_ptr, N0, N1, N2, MID, B0: tl.constexpr, B1: tl.constexpr, B2: tl.constexpr):\n",
+        "def dot_kernel(x_ptr, y_ptr, z_ptr, N0, N1, N2, MID, B0: tl.constexpr, B1: tl.constexpr, B2: tl.constexpr, B_MID: tl.constexpr):\n",
         "    pid_0 = tl.program_id(0)\n",
         "    pid_1 = tl.program_id(1)\n",
         "    pid_2 = tl.program_id(2)\n",
         "\n",
-        "test(dot_kernel, dot_spec, B={\"B0\": 16, \"B1\": 16, \"B2\": 1}, nelem={\"N0\": 32, \"N1\": 32, \"N2\": 4, \"MID\": 32})\n"
+        "test(dot_kernel, dot_spec, B={\"B0\": 16, \"B1\": 16, \"B2\": 1, \"B_MID\": 16}, nelem={\"N0\": 32, \"N1\": 32, \"N2\": 4, \"MID\": 32})\n"
       ]
     },
     {
@@ -961,8 +961,8 @@
   ],
   "metadata": {
     "colab": {
-      "provenance": [],
-      "include_colab_link": true
+      "include_colab_link": true,
+      "provenance": []
     },
     "kernelspec": {
       "display_name": ".venv",


### PR DESCRIPTION
+ fix formula on puzzle 11 to sum over dimension `L`
<img width="1572" alt="Screenshot 2024-04-10 at 11 22 25 AM" src="https://github.com/srush/Triton-Puzzles/assets/3590333/d54f6893-e277-480e-9811-3ac2dc956cde">

+ add `B_MID` on puzzle 11 for the parameter on block size to loop over the MID dimension
<img width="1551" alt="Screenshot 2024-04-10 at 11 22 14 AM" src="https://github.com/srush/Triton-Puzzles/assets/3590333/9d6528f3-dd87-4d58-a6ca-626bb06d324c">
