### PR TITLE
minor on puzzle 12

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -949,12 +949,11 @@
         "\n",
         "@triton.jit\n",
         "def quant_dot_kernel(scale_ptr, offset_ptr, weight_ptr, activation_ptr,\n",
-        "                     z_ptr, N0, N1, MID, B0: tl.constexpr, B1: tl.constexpr):\n",
+        "                     z_ptr, N0, N1, MID, B0: tl.constexpr, B1: tl.constexpr, B_MID: tl.constexpr):\n",
         "    pid_0 = tl.program_id(0)\n",
         "    pid_1 = tl.program_id(1)\n",
-        "    pid_2 = tl.program_id(2)\n",
         "\n",
-        "test(quant_dot_kernel, quant_dot_spec, B={\"B0\": 16, \"B1\": 16},\n",
+        "test(quant_dot_kernel, quant_dot_spec, B={\"B0\": 16, \"B1\": 16, \"B_MID\": 64},\n",
         "                                       nelem={\"N0\": 32, \"N1\": 32, \"MID\": 64})\n"
       ]
     }

--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -904,7 +904,7 @@
         "\n",
         "Mathematically it looks like.\n",
         "\n",
-        "$$z_{j, k} = \\sum_{k} sc_{j, l/g} (w_{j, l} - sh_{j, l/g}) \\times y_{l, k} \\text{ for } i = 1\\ldots N_2, j = 1\\ldots N_0, k = 1\\ldots N_1$$\n",
+        "$$z_{j, k} = \\sum_{l} sc_{j, \\frac{l}{g}} (w_{j, l} - sh_{j, \\frac{l}{g}}) \\times y_{l, k} \\text{ for } i = 1\\ldots N_2, j = 1\\ldots N_0, k = 1\\ldots N_1$$\n",
         "\n",
         "However, it is a bit more complex since we need to also extract the 4-bit values into floats to begin.\n",
         "\n",


### PR DESCRIPTION
minor change on puzzle 12

+ fix formula to sum over `l`
<img width="1565" alt="Screenshot 2024-04-13 at 9 16 37 PM" src="https://github.com/srush/Triton-Puzzles/assets/3590333/60121445-032d-4701-ba94-e86c195c82f6">

+ remove `pid_2` due to no batch dimension in this question
+ add parameter `B_MID` to be the block size of MID, set default to `64 = FPINT * GROUP`
<img width="1118" alt="Screenshot 2024-04-13 at 9 53 26 PM" src="https://github.com/srush/Triton-Puzzles/assets/3590333/f1669ef7-af26-4ada-b7fe-c3ef463cf460">
