### PR TITLE
Fix typo in Puzzle 9: Simple FlashAttention

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -738,7 +738,7 @@
         "\n",
         "Uses zero programs. Block size `B0` represents `k` of length `N0`.\n",
         "Block size `B0` represents `q` of length `N0`. Block size `B0` represents `v` of length `N0`.\n",
-        "Sequence length is `T`. Process it `B1 < T` elements at a time.  \n",
+        "Sequence length is `T`. Process it `B0 < T` elements at a time.  \n",
         "\n",
         "$$z_{i} = \\sum_{j} \\text{softmax}(q_1 k_1, \\ldots, q_T k_T)_j v_{j} \\text{ for } i = 1\\ldots N_0$$\n",
         "\n",


### PR DESCRIPTION
The question references `B1` when it should reference `B0`, since there is no `B1` for this puzzle.