### PR TITLE
Fix notation and clarification of Puzzle 9

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -736,11 +736,9 @@
         "\n",
         "A scalar version of FlashAttention.\n",
         "\n",
-        "Uses zero programs. Block size `B0` represents `k` of length `N0`.\n",
-        "Block size `B0` represents `q` of length `N0`. Block size `B0` represents `v` of length `N0`.\n",
-        "Sequence length is `T`. Process it `B1 < T` elements at a time.  \n",
+        "Uses **zero** programs. Block size `B0` represents `k`, `q`, and `v`, all of length `N0`. Sequence length is `T`. Process it `B1 < T` elements at a time for some `B1`.  \n",
         "\n",
-        "$$z_{i} = \\sum_{j} \\text{softmax}(q_1 k_1, \\ldots, q_T k_T)_j v_{j} \\text{ for } i = 1\\ldots N_0$$\n",
+        "$$z_{i} = \\sum_{j=1}^{N_0} \\text{softmax}(q_1 k_j, \\ldots, q_T k_j) v_{j} \\text{ for } i = 1\\ldots N_0$$\n",
         "\n",
         "This can be done in 1 loop using a similar trick from the last puzzle."
       ]


### PR DESCRIPTION
The notation for the softmax in Puzzle 9 is confusing. The current indexing is not representative of the outer product, and also the inclusion of an extra variable B1 is a bit ambiguous. I think the new description (minor change) is more clear.

The new notation also makes it clear the relationship between the `k` vector and `v` vector, which is important for understanding how the full flash attention is done.