### PR TITLE
Use == instead of - to set triton version in pip and upgrade to 3.2.0

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -46,7 +46,7 @@
     "!apt install libcairo2-dev pkg-config python3-dev\n",
     "!pip install jaxtyping\n",
     "!pip install git+https://github.com/Deep-Learning-Profiling-Tools/triton-viz@v1.1.1\n",
-    "!pip install triton==3.1.0\n",
+    "!pip install triton==3.2.0\n",
     "!pip install pycairo\n",
     "!export LC_ALL=\"en_US.UTF-8\"\n",
     "!export LD_LIBRARY_PATH=\"/usr/lib64-nvidia\"\n",


### PR DESCRIPTION
Should fix the issue seen in #32 where the Colab notebook doesn't install the older version of `triton` (`3.1.0`) and instead uses the version that comes pre-installed on Colab (`3.4.0` at the time of me writing this), causing the error.

It seems the `triton` install command was broken (at least on Colab), and changing the `triton-3.1.0` to `triton==3.1.0` seems to fix it.

As is, the `!pip install triton-3.1.0` command gives the following output:
```
ERROR: Could not find a version that satisfies the requirement triton-3.1.0 (from versions: none)
ERROR: No matching distribution found for triton-3.1.0
```

I wonder if there was some change to `pip` or the way `triton` is distributed? Since I'm guessing (hoping) it hasn't been broken since #25.

Also, as noted by @Bakameow in https://github.com/srush/Triton-Puzzles/issues/32#issuecomment-3210623072 it seems like just reverting to `3.1.0` has its own issues (pasted the error I saw below) so I also updated it to `3.2.0`, which seems to work!

Error message when running introduction demo with `3.1.0` on Colab:
```
AttributeError: type object 'JITFunction' has no attribute '_type_of'
```

I tested by creating a new Colab notebook with the updated code and making sure the packages installed and the first few code blocks ran without error.

@srush @mark14wu @Jokeren 