### PR TITLE
Fix the Puzzle 9 flash attention test block size

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -790,7 +790,7 @@
         "    # TODO: add implementation\n",
         "    return\n",
         "\n",
-        "test(flashatt_kernel, flashatt_spec, B={\"B0\":200},\n",
+        "test(flashatt_kernel, flashatt_spec, B={\"B0\": 64},\n",
         "     nelem={\"N0\": 200, \"T\": 200})"
       ]
     },


### PR DESCRIPTION
Fixes #27.

The notebook currently tests puzzle 9 with `B0=200`, but the puzzle pattern typically relies on `tl.arange(0, B0)`, which expects a power-of-two block size. This changes the example test to use `B0=64` while keeping `N0=T=200`.