### PR TITLE
Clarify the constant-add puzzle wording

### DIFF
--- a/Triton-Puzzles.ipynb
+++ b/Triton-Puzzles.ipynb
@@ -381,7 +381,7 @@
       "source": [
         "## Puzzle 2: Constant Add Block\n",
         "\n",
-        "Add a constant to a vector. Uses one program block axis (no `for` loops yet). Block size `B0` is now smaller than the shape vector `x` which is `N0`.\n",
+        "Add a constant to a vector. Uses one program block axis (no `for` loops yet). Block size `B0` is smaller than the vector length `N0`, so one axis is used to tile across the input.\n",
         "\n",
         "\n",
         "$$z_i = 10 + x_i \\text{ for } i = 1\\ldots N_0$$\n",


### PR DESCRIPTION
Fixes #30.

This updates the notebook wording to clarify that puzzle 2 uses one program block axis to tile across the input because `B0 < N0`, rather than implying there are no block axes involved.